### PR TITLE
Fix harbor placement in board editor

### DIFF
--- a/src/components/game/BoardEditor.tsx
+++ b/src/components/game/BoardEditor.tsx
@@ -149,10 +149,17 @@ export const BoardEditor: React.FC<BoardEditorProps> = ({
       const landHex = matchingHexes.find(h => h.type !== 'ocean');
       if (!oceanHex || !landHex) return;
 
+      const oceanCenter = getHexPosition(oceanHex.position.x, oceanHex.position.y, size);
       const midPoint = {
         x: (edge.from.x + edge.to.x) / 2,
         y: (edge.from.y + edge.to.y) / 2,
       };
+
+      const edgeVec = { x: edge.to.x - edge.from.x, y: edge.to.y - edge.from.y };
+      const rightNormal = { x: -edgeVec.y, y: edgeVec.x };
+      const toOcean = { x: oceanCenter.x - midPoint.x, y: oceanCenter.y - midPoint.y };
+      const dot = rightNormal.x * toOcean.x + rightNormal.y * toOcean.y;
+      const oceanSide: 'left' | 'right' = dot > 0 ? 'right' : 'left';
 
       const existingIndex = harbors.findIndex(h =>
         Math.abs(h.position.x - midPoint.x) < tolerance &&
@@ -168,6 +175,7 @@ export const BoardEditor: React.FC<BoardEditorProps> = ({
             type: selectedHarbor,
             position: midPoint,
             edge,
+            oceanSide,
           },
         ]);
       }

--- a/src/components/game/BoardEditor.tsx
+++ b/src/components/game/BoardEditor.tsx
@@ -21,7 +21,7 @@ const getHexPosition = (col: number, row: number, size: number) => ({
 });
 
 const resourceTypes: ResourceType[] = ['wood', 'brick', 'sheep', 'wheat', 'ore', 'desert', 'ocean'];
-const harborTypes: HarborType[] = ['wood', 'brick', 'sheep', 'wheat', 'ore', 'ocean', 'any'];
+const harborTypes: HarborType[] = ['wood', 'brick', 'sheep', 'wheat', 'ore', 'any'];
 const numberTokens = [2, 3, 3, 4, 4, 5, 5, 6, 6, 8, 8, 9, 9, 10, 10, 11, 11, 12];
 
 interface BoardEditorProps {

--- a/src/components/game/BoardEditor.tsx
+++ b/src/components/game/BoardEditor.tsx
@@ -84,7 +84,7 @@ export const BoardEditor: React.FC<BoardEditorProps> = ({
 
   const handleEdgeClick = useCallback((edge: Edge) => {
     if (selectedTool === 'road' && selectedPlayer) {
-      const existingRoad = roads.find(r => 
+      const existingRoad = roads.find(r =>
         (Math.abs(r.position.from.x - edge.from.x) < 5 && Math.abs(r.position.from.y - edge.from.y) < 5 &&
          Math.abs(r.position.to.x - edge.to.x) < 5 && Math.abs(r.position.to.y - edge.to.y) < 5) ||
         (Math.abs(r.position.from.x - edge.to.x) < 5 && Math.abs(r.position.from.y - edge.to.y) < 5 &&
@@ -103,7 +103,29 @@ export const BoardEditor: React.FC<BoardEditorProps> = ({
         setRoads(prev => [...prev, newRoad]);
       }
     }
-  }, [selectedTool, selectedPlayer, roads]);
+    if (selectedTool === 'harbor') {
+      const midPoint = {
+        x: (edge.from.x + edge.to.x) / 2,
+        y: (edge.from.y + edge.to.y) / 2
+      };
+      const existingIndex = harbors.findIndex(h =>
+        Math.abs(h.position.x - midPoint.x) < 5 &&
+        Math.abs(h.position.y - midPoint.y) < 5
+      );
+
+      if (existingIndex !== -1) {
+        setHarbors(prev => prev.filter((_, i) => i !== existingIndex));
+      } else {
+        setHarbors(prev => [
+          ...prev,
+          {
+            type: selectedHarbor,
+            position: midPoint
+          }
+        ]);
+      }
+    }
+  }, [selectedTool, selectedPlayer, roads, harbors, selectedHarbor]);
 
   const randomizeBoard = () => {
     const landTiles = hexTiles.filter(h => h.type !== 'ocean');

--- a/src/components/game/HexBoard.tsx
+++ b/src/components/game/HexBoard.tsx
@@ -311,14 +311,18 @@ export const HexBoard: React.FC<HexBoardProps> = ({
           const length = Math.sqrt(dx * dx + dy * dy);
           const offsetX = -(dy / length) * 15;
           const offsetY = (dx / length) * 15;
+
+          const fill = harbor.type === 'any' ? '#ffffff' : resourceColors[harbor.type as ResourceType];
+          const textColor = harbor.type === 'any' ? '#000000' : '#ffffff';
+
           return (
             <g
               key={`harbor-${i}`}
               transform={`translate(${midX + offsetX},${midY + offsetY}) rotate(${angle})`}
               pointerEvents="none"
             >
-              <rect x={-length / 2} y={-8} width={length} height={16} fill="#fff" stroke="#000" strokeWidth={2} />
-              <text textAnchor="middle" dy={4} className="text-xs">
+              <rect x={-length / 2} y={-8} width={length} height={16} fill={fill} stroke="#000" strokeWidth={2} />
+              <text textAnchor="middle" dy={4} className="text-xs" fill={textColor}>
                 {harbor.type === 'any' ? '3:1' : `2:1 ${harbor.type}`}
               </text>
             </g>

--- a/src/components/game/HexBoard.tsx
+++ b/src/components/game/HexBoard.tsx
@@ -292,9 +292,9 @@ export const HexBoard: React.FC<HexBoardProps> = ({
                 playerColors={playerColors}
                 robberPosition={robberPosition}
                 onVertexClick={onVertexClick ? (vertex) => onVertexClick({ x: x + vertex.x, y: y + vertex.y }) : undefined}
-                onEdgeClick={onEdgeClick ? (edge) => onEdgeClick({ 
-                  from: { x: x + edge.from.x, y: y + edge.from.y }, 
-                  to: { x: x + edge.to.x, y: y + edge.to.y } 
+                onEdgeClick={onEdgeClick ? (edge) => onEdgeClick({
+                  from: { x: x + edge.from.x, y: y + edge.from.y },
+                  to: { x: x + edge.to.x, y: y + edge.to.y }
                 }) : undefined}
                 onHexClick={onHexClick}
                 isInteractive={isInteractive}
@@ -302,6 +302,14 @@ export const HexBoard: React.FC<HexBoardProps> = ({
             </g>
           );
         })}
+        {harbors.map((harbor, i) => (
+          <g key={`harbor-${i}`} transform={`translate(${harbor.position.x},${harbor.position.y})`}>
+            <circle r={10} fill="#fff" stroke="#000" strokeWidth={2} />
+            <text textAnchor="middle" dy={4} className="text-xs">
+              {harbor.type === 'any' ? '3:1' : `2:1 ${harbor.type}`}
+            </text>
+          </g>
+        ))}
       </svg>
     </div>
   );

--- a/src/components/game/HexBoard.tsx
+++ b/src/components/game/HexBoard.tsx
@@ -302,14 +302,28 @@ export const HexBoard: React.FC<HexBoardProps> = ({
             </g>
           );
         })}
-        {harbors.map((harbor, i) => (
-          <g key={`harbor-${i}`} transform={`translate(${harbor.position.x},${harbor.position.y})`}>
-            <circle r={10} fill="#fff" stroke="#000" strokeWidth={2} />
-            <text textAnchor="middle" dy={4} className="text-xs">
-              {harbor.type === 'any' ? '3:1' : `2:1 ${harbor.type}`}
-            </text>
-          </g>
-        ))}
+        {harbors.map((harbor, i) => {
+          const midX = (harbor.edge.from.x + harbor.edge.to.x) / 2;
+          const midY = (harbor.edge.from.y + harbor.edge.to.y) / 2;
+          const dx = harbor.edge.to.x - harbor.edge.from.x;
+          const dy = harbor.edge.to.y - harbor.edge.from.y;
+          const angle = (Math.atan2(dy, dx) * 180) / Math.PI;
+          const length = Math.sqrt(dx * dx + dy * dy);
+          const offsetX = -(dy / length) * 15;
+          const offsetY = (dx / length) * 15;
+          return (
+            <g
+              key={`harbor-${i}`}
+              transform={`translate(${midX + offsetX},${midY + offsetY}) rotate(${angle})`}
+              pointerEvents="none"
+            >
+              <rect x={-length / 2} y={-8} width={length} height={16} fill="#fff" stroke="#000" strokeWidth={2} />
+              <text textAnchor="middle" dy={4} className="text-xs">
+                {harbor.type === 'any' ? '3:1' : `2:1 ${harbor.type}`}
+              </text>
+            </g>
+          );
+        })}
       </svg>
     </div>
   );

--- a/src/components/game/HexBoard.tsx
+++ b/src/components/game/HexBoard.tsx
@@ -309,8 +309,9 @@ export const HexBoard: React.FC<HexBoardProps> = ({
           const dy = harbor.edge.to.y - harbor.edge.from.y;
           const angle = (Math.atan2(dy, dx) * 180) / Math.PI;
           const length = Math.sqrt(dx * dx + dy * dy);
-          const offsetX = -(dy / length) * 15;
-          const offsetY = (dx / length) * 15;
+          const sideSign = harbor.oceanSide === 'right' ? 1 : -1;
+          const offsetX = sideSign * -(dy / length) * 15;
+          const offsetY = sideSign * (dx / length) * 15;
 
           const fill = harbor.type === 'any' ? '#ffffff' : resourceColors[harbor.type as ResourceType];
           const textColor = harbor.type === 'any' ? '#000000' : '#ffffff';

--- a/src/models/types.ts
+++ b/src/models/types.ts
@@ -1,7 +1,14 @@
 // Core data models for the Catan Master Pro application
 
 export type ResourceType = 'wood' | 'brick' | 'sheep' | 'wheat' | 'ore' | 'desert' | 'ocean';
-export type HarborType = ResourceType | 'any' | 'none';
+export type HarborType =
+  | 'wood'
+  | 'brick'
+  | 'sheep'
+  | 'wheat'
+  | 'ore'
+  | 'any'
+  | 'none';
 export type PlayerColor = 'red' | 'blue' | 'white' | 'orange' | 'green' | 'brown';
 
 export interface Player {

--- a/src/models/types.ts
+++ b/src/models/types.ts
@@ -71,6 +71,7 @@ export interface Harbor {
     x: number;
     y: number;
   };
+  edge: Edge;
 }
 
 export interface NumberToken {

--- a/src/models/types.ts
+++ b/src/models/types.ts
@@ -72,6 +72,11 @@ export interface Harbor {
     y: number;
   };
   edge: Edge;
+  /**
+   * Side of the edge where the ocean hex lies relative to the edge orientation
+   * ("right" means the ocean is to the right when moving from edge.from to edge.to)
+   */
+  oceanSide: 'left' | 'right';
 }
 
 export interface NumberToken {


### PR DESCRIPTION
## Summary
- enable harbor placement on board edges
- render harbors on the board

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684e90f60438832ab43a40af434a9c29