### PR TITLE
ボードレイアウトをJPGでエクスポート

### DIFF
--- a/src/components/game/BoardEditor.tsx
+++ b/src/components/game/BoardEditor.tsx
@@ -349,10 +349,25 @@ export const BoardEditor: React.FC<BoardEditorProps> = ({
     setRobberPosition(defaultBoard.robberPosition);
   };
 
+  // text 要素の computed style を inline 化することで
+  // SVG を画像変換しても文字サイズが変わらないようにする
+  const inlineTextStyles = (svg: SVGSVGElement) => {
+    const texts = svg.querySelectorAll('text');
+    texts.forEach((t) => {
+      const style = window.getComputedStyle(t);
+      t.setAttribute('font-size', style.fontSize);
+      t.setAttribute('font-family', style.fontFamily);
+      t.setAttribute('font-weight', style.fontWeight);
+    });
+  };
+
   const exportBoard = () => {
     // svg を画像化してダウンロードする
     const svgEl = svgRef.current;
     if (!svgEl) return;
+
+    // Tailwind のクラスによる文字サイズを保持するため事前に inline 化
+    inlineTextStyles(svgEl);
 
     const serializer = new XMLSerializer();
     const svgStr = serializer.serializeToString(svgEl);

--- a/src/components/game/HexBoard.tsx
+++ b/src/components/game/HexBoard.tsx
@@ -216,7 +216,8 @@ interface HexBoardProps {
   highlightEdges?: Edge[];
 }
 
-export const HexBoard: React.FC<HexBoardProps> = ({
+// svg を他コンポーネントから参照するため forwardRef を利用
+export const HexBoard = React.forwardRef<SVGSVGElement, HexBoardProps>(({
   hexes,
   harbors = [],
   buildings = [],
@@ -231,7 +232,7 @@ export const HexBoard: React.FC<HexBoardProps> = ({
   isInteractive = false,
   highlightVertices = [],
   highlightEdges = [],
-}) => {
+}, ref) => {
   const getHexPosition = React.useCallback((col: number, row: number) => ({
     x: col * (size * Math.sqrt(3)),
     y: row * (size * 1.5),
@@ -251,6 +252,7 @@ export const HexBoard: React.FC<HexBoardProps> = ({
   return (
     <div className={`relative ${className}`}>
       <svg
+        ref={ref}
         width={boardWidth}
         height={boardHeight}
         className="border rounded-lg bg-blue-50"
@@ -386,4 +388,4 @@ export const HexBoard: React.FC<HexBoardProps> = ({
       </svg>
     </div>
   );
-};
+});


### PR DESCRIPTION
## 概要
ボードエディターのエクスポート機能を画像出力できるよう改善しました。

## 変更理由
ボードレイアウトを画像として共有したいという要望に対応するためです。

## 主な変更点
- `HexBoard` を `forwardRef` 化し、SVG 要素を外部から参照可能に
- `BoardEditor` で SVG を JPG に変換してダウンロードする処理を追加


------
https://chatgpt.com/codex/tasks/task_e_684ec6579628832a8c7053a819df035f