### PR TITLE
盗賊アイコン表示位置の調整

### DIFF
--- a/src/components/game/HexBoard.tsx
+++ b/src/components/game/HexBoard.tsx
@@ -103,9 +103,9 @@ const Hex: React.FC<HexProps> = ({
         </>
       )}
       
-      {/* 盗賊 */}
+      {/* 盗賊 - 視認性向上のため少し上に配置 */}
       {hasRobber && hex.type !== 'ocean' && (
-        <circle cx={0} cy={-20} r={8} fill="#000000" stroke="#ffffff" strokeWidth={2} className="pointer-events-none" />
+        <circle cx={0} cy={-30} r={8} fill="#000000" stroke="#ffffff" strokeWidth={2} className="pointer-events-none" />
       )}
       
       {/* 道路 */}


### PR DESCRIPTION
## 概要
HexBoard 内で表示する盗賊アイコンを少し上へ移動しました。

## 変更理由
数字トークンとの重なりを避け、視認性を高めるためです。

## 主な変更点
- 盗賊描画位置を y = -30 に変更
- コメントを日本語で追加

## テスト
- `npm run lint` を実行しましたが、依存モジュール不足のため失敗しました。

------
https://chatgpt.com/codex/tasks/task_e_684ed77ae344832a9fc0b6675b7a14ee