### PR TITLE
generateDefaultBoardの共通化

### DIFF
--- a/src/components/game/BoardEditor.tsx
+++ b/src/components/game/BoardEditor.tsx
@@ -4,7 +4,7 @@ import { Button } from '../ui/Button';
 import { HexTile, ResourceType, Harbor, HarborType, BoardSetup, GamePlayer, Building, Road, Vertex, Edge } from '../../models/types';
 import { HexBoard } from './HexBoard';
 import { Shuffle, RotateCcw, Save, Download, Upload, Home, Route } from 'lucide-react';
-import { generateDefaultBoard } from './GameForm';
+import { generateDefaultBoard } from '../../utils/board';
 
 const computeVertices = (size: number): Vertex[] => {
   const verts: Vertex[] = [];

--- a/src/components/game/BoardTemplates.tsx
+++ b/src/components/game/BoardTemplates.tsx
@@ -3,7 +3,7 @@ import { Card, CardHeader, CardTitle, CardContent } from '../ui/Card';
 import { Button } from '../ui/Button';
 import { BoardSetup, HexTile, ResourceType, Harbor } from '../../models/types';
 import { HexBoard } from './HexBoard';
-import { generateDefaultBoard } from './GameForm';
+import { generateDefaultBoard } from '../../utils/board';
 
 interface BoardTemplatesProps {
   onSelectTemplate: (board: BoardSetup) => void;

--- a/src/components/game/GameForm.tsx
+++ b/src/components/game/GameForm.tsx
@@ -8,6 +8,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { GameSession, PlayerColor, GamePlayer, BoardSetup } from '../../models/types';
 import { useGameStore } from '../../store/gameStore';
 import { format } from 'date-fns';
+import { generateDefaultBoard } from '../../utils/board';
 
 const playerColors: PlayerColor[] = ['red', 'blue', 'white', 'orange', 'green', 'brown'];
 
@@ -464,68 +465,3 @@ export const GameForm: React.FC<GameFormProps> = ({ onSave, initialGame }) => {
     </form>
   );
 };
-
-// Board generation functions for different game types
-export const generateDefaultBoard = (gameType: 'standard' | 'seafarers' | 'cities' | 'traders' | 'america' = 'standard'): BoardSetup => {
-  const hexes: HexTile[] = [];
-  
-  let layout: number[];
-  let oceanIndices: Set<number>;
-  
-  switch (gameType) {
-    case 'seafarers':
-      layout = [5, 6, 7, 8, 9, 8, 7, 6, 5];
-      oceanIndices = new Set([0,1,2,3,4,5,11,12,18,19,26,27,34,35,41,42,43,44,45,46,47]);
-      break;
-    case 'cities':
-      layout = [4, 5, 6, 7, 6, 5, 4];
-      oceanIndices = new Set([0,1,2,3,4,8,9,14,15,21,22,27,28,32,33,34,35,36]);
-      break;
-    case 'traders':
-      layout = [4, 5, 6, 7, 6, 5, 4];
-      oceanIndices = new Set([0,1,2,3,4,8,9,14,15,21,22,27,28,32,33,34,35,36]);
-      break;
-    case 'america':
-      layout = [3, 4, 5, 6, 5, 4, 3];
-      oceanIndices = new Set([0,1,2,3,7,8,12,13,18,19,23,24,25,26,27]);
-      break;
-    default: // standard
-      layout = [4, 5, 6, 7, 6, 5, 4];
-      oceanIndices = new Set([0,1,2,3,4,8,9,14,15,21,22,27,28,32,33,34,35,36]);
-  }
-
-  const resources = ['wood', 'brick', 'sheep', 'wheat', 'ore'];
-  let hexId = 0;
-  
-  layout.forEach((rowSize, rowIndex) => {
-    const xOffset = (layout.length - rowSize) / 2;
-    for (let x = 0; x < rowSize; x++, hexId++) {
-      const type: ResourceType =
-        oceanIndices.has(hexId) ? 'ocean'
-        : hexId === Math.floor(layout.reduce((a, b) => a + b, 0) / 2) ? 'desert'
-        : resources[hexId % resources.length];
-
-      hexes.push({
-        id: `hex-${hexId}`,
-        type,
-        number: !['ocean','desert'].includes(type)
-          ? [2,3,3,4,4,5,5,6,6,8,8,9,9,10,10,11,11,12][hexId % 18]
-          : undefined,
-        position: { x: x + xOffset, y: rowIndex }
-      });
-    }
-  });
-
-  return {
-    hexTiles: hexes,
-    numberTokens: [],
-    harbors: [],
-    robberPosition: { x: Math.floor(layout[Math.floor(layout.length/2)] / 2), y: Math.floor(layout.length / 2) },
-    buildings: [],
-    roads: []
-  };
-};
-
-// Import HexBoard component
-import { HexBoard } from './HexBoard';
-import { HexTile, ResourceType } from '../../models/types';

--- a/src/components/game/GameSetup.tsx
+++ b/src/components/game/GameSetup.tsx
@@ -4,7 +4,7 @@ import { Button } from '../ui/Button';
 import { useGameStore } from '../../store/gameStore';
 import { useNavigate } from 'react-router-dom';
 import { GamePlayer, PlayerColor } from '../../models/types';
-import { generateDefaultBoard } from './GameForm';
+import { generateDefaultBoard } from '../../utils/board';
 import { Plus, Minus, Play, Users } from 'lucide-react';
 import { v4 as uuidv4 } from 'uuid';
 

--- a/src/utils/board.ts
+++ b/src/utils/board.ts
@@ -1,0 +1,82 @@
+// ボードの初期配置を生成するユーティリティ関数
+// ゲームタイプごとのレイアウトや海タイルの位置をまとめて定義している
+
+import { BoardSetup, HexTile, ResourceType } from '../models/types';
+
+/**
+ * 指定されたゲームタイプに応じたデフォルトのボード設定を返す
+ * TODO: ボードの詳細設定は将来的にデータファイル化する可能性がある
+ */
+export const generateDefaultBoard = (
+  gameType: 'standard' | 'seafarers' | 'cities' | 'traders' | 'america' = 'standard'
+): BoardSetup => {
+  const hexes: HexTile[] = [];
+
+  let layout: number[];
+  let oceanIndices: Set<number>;
+
+  switch (gameType) {
+    case 'seafarers':
+      layout = [5, 6, 7, 8, 9, 8, 7, 6, 5];
+      oceanIndices = new Set([
+        0, 1, 2, 3, 4, 5, 11, 12, 18, 19, 26, 27, 34, 35, 41, 42, 43, 44, 45, 46, 47
+      ]);
+      break;
+    case 'cities':
+      layout = [4, 5, 6, 7, 6, 5, 4];
+      oceanIndices = new Set([
+        0, 1, 2, 3, 4, 8, 9, 14, 15, 21, 22, 27, 28, 32, 33, 34, 35, 36
+      ]);
+      break;
+    case 'traders':
+      layout = [4, 5, 6, 7, 6, 5, 4];
+      oceanIndices = new Set([
+        0, 1, 2, 3, 4, 8, 9, 14, 15, 21, 22, 27, 28, 32, 33, 34, 35, 36
+      ]);
+      break;
+    case 'america':
+      layout = [3, 4, 5, 6, 5, 4, 3];
+      oceanIndices = new Set([0, 1, 2, 3, 7, 8, 12, 13, 18, 19, 23, 24, 25, 26, 27]);
+      break;
+    default: // standard
+      layout = [4, 5, 6, 7, 6, 5, 4];
+      oceanIndices = new Set([
+        0, 1, 2, 3, 4, 8, 9, 14, 15, 21, 22, 27, 28, 32, 33, 34, 35, 36
+      ]);
+  }
+
+  const resources: ResourceType[] = ['wood', 'brick', 'sheep', 'wheat', 'ore'];
+  let hexId = 0;
+
+  layout.forEach((rowSize, rowIndex) => {
+    const xOffset = (layout.length - rowSize) / 2;
+    for (let x = 0; x < rowSize; x++, hexId++) {
+      const type: ResourceType = oceanIndices.has(hexId)
+        ? 'ocean'
+        : hexId === Math.floor(layout.reduce((a, b) => a + b, 0) / 2)
+        ? 'desert'
+        : resources[hexId % resources.length];
+
+      hexes.push({
+        id: `hex-${hexId}`,
+        type,
+        number: !['ocean', 'desert'].includes(type)
+          ? [2, 3, 3, 4, 4, 5, 5, 6, 6, 8, 8, 9, 9, 10, 10, 11, 11, 12][hexId % 18]
+          : undefined,
+        position: { x: x + xOffset, y: rowIndex }
+      });
+    }
+  });
+
+  return {
+    hexTiles: hexes,
+    numberTokens: [],
+    harbors: [],
+    robberPosition: {
+      x: Math.floor(layout[Math.floor(layout.length / 2)] / 2),
+      y: Math.floor(layout.length / 2)
+    },
+    buildings: [],
+    roads: []
+  };
+};


### PR DESCRIPTION
## 概要
ボード初期化処理を `src/utils/board.ts` に切り出し、各コンポーネントから参照するよう修正しました。

## 変更理由
`GameForm` と `BoardEditor` 間で発生していたインポート循環を解消するため。

## 主な変更点
- `src/utils/board.ts` を新規追加
- `GameForm.tsx`・`BoardEditor.tsx` などでユーティリティを参照するよう更新
- `GameForm.tsx` からボード生成処理を削除


------
https://chatgpt.com/codex/tasks/task_e_684eec401c74832a9e86471d1dabd9db