### PR TITLE
GameForm の HexBoard import 重複解消

### DIFF
--- a/src/components/game/GameForm.tsx
+++ b/src/components/game/GameForm.tsx
@@ -572,6 +572,3 @@ export const generateDefaultDeck = (): DevelopmentCardDeck => ({
   totalRemaining: 25
 });
 
-// Import HexBoard component
-import { HexBoard } from './HexBoard';
-import { HexTile, ResourceType } from '../../models/types';


### PR DESCRIPTION
## 概要
GameForm.tsx の末尾に重複していた HexBoard などの import を削除し、冒頭の import セクションのみに整理しました。

## 変更理由
重複した import が残っていると lint 実行時にエラーが発生するため。

## 主な変更点
- GameForm.tsx 末尾の不要な import 行を削除
- HexBoard コンポーネントの import を先頭で一元化

------
https://chatgpt.com/codex/tasks/task_e_684ef6a0133c832aa4ba3400c69e4e72