### PR TITLE
プレイヤーカード編集機能の改善

### DIFF
--- a/src/components/game/DevelopmentCardEditor.tsx
+++ b/src/components/game/DevelopmentCardEditor.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { Card, CardHeader, CardTitle, CardContent } from '../ui/Card';
 import { Button } from '../ui/Button';
 import {
-  DevelopmentCardDeck,
   GamePlayer,
   DevelopmentCard,
   DevelopmentCardType
@@ -20,20 +19,16 @@ import {
 import { v4 as uuidv4 } from 'uuid';
 
 interface DevelopmentCardEditorProps {
-  deck: DevelopmentCardDeck;
-  players: GamePlayer[];
-  onDeckChange: (deck: DevelopmentCardDeck) => void;
-  onPlayersChange: (players: GamePlayer[]) => void;
+  player: GamePlayer;
+  onChange?: (player: GamePlayer) => void;
 }
 
 export const DevelopmentCardEditor: React.FC<DevelopmentCardEditorProps> = ({
-  deck,
-  players,
-  onDeckChange,
-  onPlayersChange
+  player,
+  onChange
 }) => {
-  // ストアの状態も更新してフォームと同期させる
-  const { updateDevelopmentCardDeck, updatePlayerDevelopmentCards } = useGameStore();
+  // ストアとフォーム状態を同期させるためストア更新関数を取得
+  const { updatePlayerDevelopmentCards } = useGameStore();
 
   const cardIcons: Record<DevelopmentCardType, JSX.Element> = {
     knight: <Sword size={16} className="text-red-600" />,
@@ -41,94 +36,6 @@ export const DevelopmentCardEditor: React.FC<DevelopmentCardEditorProps> = ({
     road_building: <Route size={16} className="text-blue-600" />,
     year_of_plenty: <Coins size={16} className="text-green-600" />,
     monopoly: <Building size={16} className="text-purple-600" />
-  };
-
-  // デッキの各枚数を変更した際に総残数も計算し直す
-  const handleDeckInput = (
-    field: keyof Omit<DevelopmentCardDeck, 'victoryPoints' | 'totalRemaining'>,
-    value: number
-  ) => {
-    const updated = { ...deck, [field]: Math.max(0, value) };
-    updated.totalRemaining =
-      updated.knights +
-      updated.roadBuilding +
-      updated.yearOfPlenty +
-      updated.monopoly +
-      updated.victoryPoints.length;
-    onDeckChange(updated);
-    updateDevelopmentCardDeck(updated);
-  };
-
-  // 勝利点カードは配列で管理されているため数値入力に合わせて生成する
-  const handleVictoryPointCount = (value: number) => {
-    const count = Math.max(0, value);
-    let vpCards = deck.victoryPoints.slice(0, count);
-    if (count > deck.victoryPoints.length) {
-      for (let i = deck.victoryPoints.length; i < count; i++) {
-        vpCards.push({
-          id: uuidv4(),
-          type: 'victory_point',
-          name: 'Victory Point',
-          isPlayed: false,
-          victoryPointValue: 1
-        });
-      }
-    }
-    const updated = { ...deck, victoryPoints: vpCards };
-    updated.totalRemaining =
-      updated.knights +
-      updated.roadBuilding +
-      updated.yearOfPlenty +
-      updated.monopoly +
-      updated.victoryPoints.length;
-    onDeckChange(updated);
-    updateDevelopmentCardDeck(updated);
-  };
-
-  // プレイヤーにカードを追加する処理
-  const addCardToPlayer = (playerId: string, type: DevelopmentCardType) => {
-    const newCard: DevelopmentCard = {
-      id: uuidv4(),
-      type,
-      name:
-        type === 'victory_point'
-          ? 'Victory Point'
-          : type.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase()),
-      isPlayed: false
-    };
-    const updatedPlayers = players.map(p =>
-      p.id === playerId ? { ...p, developmentCards: [...p.developmentCards, newCard] } : p
-    );
-    onPlayersChange(updatedPlayers);
-    const target = updatedPlayers.find(p => p.id === playerId)!;
-    updatePlayerDevelopmentCards(playerId, target.developmentCards);
-  };
-
-  // カード削除
-  const removePlayerCard = (playerId: string, cardId: string) => {
-    const updatedPlayers = players.map(p =>
-      p.id === playerId ? { ...p, developmentCards: p.developmentCards.filter(c => c.id !== cardId) } : p
-    );
-    onPlayersChange(updatedPlayers);
-    const target = updatedPlayers.find(p => p.id === playerId)!;
-    updatePlayerDevelopmentCards(playerId, target.developmentCards);
-  };
-
-  // 使用済み切り替え
-  const togglePlayed = (playerId: string, cardId: string) => {
-    const updatedPlayers = players.map(p =>
-      p.id === playerId
-        ? {
-            ...p,
-            developmentCards: p.developmentCards.map(c =>
-              c.id === cardId ? { ...c, isPlayed: !c.isPlayed } : c
-            )
-          }
-        : p
-    );
-    onPlayersChange(updatedPlayers);
-    const target = updatedPlayers.find(p => p.id === playerId)!;
-    updatePlayerDevelopmentCards(playerId, target.developmentCards);
   };
 
   const cardTypeOptions: { value: DevelopmentCardType; label: string }[] = [
@@ -139,108 +46,99 @@ export const DevelopmentCardEditor: React.FC<DevelopmentCardEditorProps> = ({
     { value: 'monopoly', label: 'Monopoly' }
   ];
 
+  // カード変更時の共通処理
+  const applyChanges = (cards: DevelopmentCard[]) => {
+    const updated = { ...player, developmentCards: cards };
+    updatePlayerDevelopmentCards(player.id, cards);
+    onChange?.(updated);
+  };
+
+  // 新しいカードを追加
+  const addCard = (type: DevelopmentCardType) => {
+    const newCard: DevelopmentCard = {
+      id: uuidv4(),
+      type,
+      name:
+        type === 'victory_point'
+          ? 'Victory Point'
+          : type.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase()),
+      isPlayed: false
+    };
+    applyChanges([...player.developmentCards, newCard]);
+  };
+
+  // カード削除処理
+  const removeCard = (cardId: string) => {
+    applyChanges(player.developmentCards.filter(c => c.id !== cardId));
+  };
+
+  // 使用済みフラグ切り替え
+  const togglePlayed = (cardId: string) => {
+    applyChanges(
+      player.developmentCards.map(c =>
+        c.id === cardId ? { ...c, isPlayed: !c.isPlayed } : c
+      )
+    );
+  };
+
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Development Cards</CardTitle>
+        <CardTitle>{player.name} Cards</CardTitle>
       </CardHeader>
-      <CardContent className="space-y-4">
-        <div>
-          <div className="grid grid-cols-2 gap-3 mb-2">
-            {(['knights', 'roadBuilding', 'yearOfPlenty', 'monopoly'] as const).map(field => (
-              <label key={field} className="flex items-center space-x-2 text-sm">
-                {cardIcons[
-                  field === 'knights'
-                    ? 'knight'
-                    : field === 'roadBuilding'
-                    ? 'road_building'
-                    : field === 'yearOfPlenty'
-                    ? 'year_of_plenty'
-                    : 'monopoly'
-                ]}
-                <span className="w-20 capitalize">{field.replace(/([A-Z])/g, ' $1')}</span>
-                <input
-                  type="number"
-                  min={0}
-                  value={deck[field]}
-                  onChange={e => handleDeckInput(field, Number(e.target.value))}
-                  className="w-16 border border-gray-300 rounded p-1 text-xs"
-                />
-              </label>
-            ))}
-            <label className="flex items-center space-x-2 text-sm">
-              {cardIcons['victory_point']}
-              <span className="w-20">Victory</span>
-              <input
-                type="number"
-                min={0}
-                value={deck.victoryPoints.length}
-                onChange={e => handleVictoryPointCount(Number(e.target.value))}
-                className="w-16 border border-gray-300 rounded p-1 text-xs"
-              />
-            </label>
-          </div>
-          <div className="text-xs text-gray-600">Remaining: {deck.totalRemaining}</div>
-        </div>
-
-        <div className="space-y-3">
-          {players.map(player => (
-            <div key={player.id} className="border rounded p-2 space-y-2">
-              <div className="flex items-center justify-between">
-                <div className="flex items-center">
-                  <div className="w-3 h-3 rounded-full mr-2" style={{ backgroundColor: player.color }} />
-                  <span className="text-sm font-medium">{player.name}</span>
-                </div>
-                <select
-                  className="border border-gray-300 rounded text-xs p-1"
-                  onChange={e => {
-                    const type = e.target.value as DevelopmentCardType;
-                    if (type) {
-                      addCardToPlayer(player.id, type);
-                      e.currentTarget.selectedIndex = 0;
-                    }
-                  }}
-                >
-                  <option value="">Add Card</option>
-                  {cardTypeOptions.map(opt => (
-                    <option key={opt.value} value={opt.value}>
-                      {opt.label}
-                    </option>
-                  ))}
-                </select>
-              </div>
-              {player.developmentCards.length > 0 && (
-                <div className="space-y-1 text-xs">
-                  {player.developmentCards.map(card => (
-                    <div key={card.id} className="flex items-center justify-between border rounded px-2 py-1">
-                      <div className="flex items-center space-x-2">
-                        {cardIcons[card.type]}
-                        <span>{card.name}</span>
-                        {card.isPlayed && <span className="text-gray-500">(used)</span>}
-                      </div>
-                      <div className="flex items-center space-x-1">
-                        <Button
-                          type="button"
-                          size="sm"
-                          variant="ghost"
-                          onClick={() => togglePlayed(player.id, card.id)}
-                          icon={card.isPlayed ? <Minus size={12} /> : <Plus size={12} />}
-                        />
-                        <Button
-                          type="button"
-                          size="sm"
-                          variant="ghost"
-                          onClick={() => removePlayerCard(player.id, card.id)}
-                          icon={<Minus size={12} />}
-                        />
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              )}
-            </div>
+      <CardContent className="space-y-3">
+        <select
+          className="border border-gray-300 rounded text-xs p-1"
+          onChange={e => {
+            const type = e.target.value as DevelopmentCardType;
+            if (type) {
+              addCard(type);
+              e.currentTarget.selectedIndex = 0;
+            }
+          }}
+        >
+          <option value="">Add Card</option>
+          {cardTypeOptions.map(opt => (
+            <option key={opt.value} value={opt.value}>
+              {opt.label}
+            </option>
           ))}
-        </div>
+        </select>
+
+        {player.developmentCards.length > 0 && (
+          <div className="space-y-1 text-xs">
+            {player.developmentCards.map(card => (
+              <div
+                key={card.id}
+                className="flex items-center justify-between border rounded px-2 py-1"
+              >
+                <div className="flex items-center space-x-2">
+                  {cardIcons[card.type]}
+                  <span>{card.name}</span>
+                  {card.isPlayed && (
+                    <span className="text-gray-500">(used)</span>
+                  )}
+                </div>
+                <div className="flex items-center space-x-1">
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="ghost"
+                    onClick={() => togglePlayed(card.id)}
+                    icon={card.isPlayed ? <Minus size={12} /> : <Plus size={12} />}
+                  />
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="ghost"
+                    onClick={() => removeCard(card.id)}
+                    icon={<Minus size={12} />}
+                  />
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
       </CardContent>
     </Card>
   );

--- a/src/components/game/GameForm.tsx
+++ b/src/components/game/GameForm.tsx
@@ -4,6 +4,7 @@ import { Card, CardHeader, CardTitle, CardContent } from '../ui/Card';
 import { BoardEditor } from './BoardEditor';
 import { BoardTemplates } from './BoardTemplates';
 import { HexBoard } from './HexBoard';
+import { DevelopmentCardEditor } from './DevelopmentCardEditor';
 import { Plus, Minus, UserPlus, X, Save, Settings, Grid } from 'lucide-react';
 import { v4 as uuidv4 } from 'uuid';
 import { GameSession, PlayerColor, GamePlayer, BoardSetup, HexTile, ResourceType } from '../../models/types';
@@ -327,40 +328,50 @@ export const GameForm: React.FC<GameFormProps> = ({ onSave, initialGame }) => {
             ) : (
               <div className="space-y-3">
                 {gamePlayers.map((player) => (
-                  <div key={player.id} className="flex items-center space-x-4 p-3 bg-gray-50 rounded-md">
-                    <div 
-                      className="h-4 w-4 rounded-full" 
-                      style={{ backgroundColor: player.color }}
-                    />
-                    <div className="flex-1">
-                      <span className="font-medium">{player.name}</span>
-                    </div>
-                    <div className="flex items-center space-x-2">
+                  <div key={player.id} className="space-y-2 p-3 bg-gray-50 rounded-md">
+                    <div className="flex items-center space-x-4">
+                      <div
+                        className="h-4 w-4 rounded-full"
+                        style={{ backgroundColor: player.color }}
+                      />
+                      <div className="flex-1">
+                        <span className="font-medium">{player.name}</span>
+                      </div>
+                      <div className="flex items-center space-x-2">
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => updatePlayerScore(player.id, Math.max(0, player.score - 1))}
+                          icon={<Minus size={16} />}
+                        />
+                        <span className="w-8 text-center">{player.score}</span>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => updatePlayerScore(player.id, player.score + 1)}
+                          icon={<Plus size={16} />}
+                        />
+                      </div>
+                      <div className="text-sm text-gray-500">
+                        Rank: {player.rank}
+                      </div>
                       <Button
                         type="button"
                         variant="ghost"
                         size="sm"
-                        onClick={() => updatePlayerScore(player.id, Math.max(0, player.score - 1))}
-                        icon={<Minus size={16} />}
-                      />
-                      <span className="w-8 text-center">{player.score}</span>
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="sm"
-                        onClick={() => updatePlayerScore(player.id, player.score + 1)}
-                        icon={<Plus size={16} />}
+                        onClick={() => removePlayer(player.id)}
+                        icon={<X size={16} />}
                       />
                     </div>
-                    <div className="text-sm text-gray-500">
-                      Rank: {player.rank}
-                    </div>
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="sm"
-                      onClick={() => removePlayer(player.id)}
-                      icon={<X size={16} />}
+                    <DevelopmentCardEditor
+                      player={player}
+                      onChange={(p) =>
+                        setGamePlayers(current =>
+                          current.map(g => (g.id === p.id ? p : g))
+                        )
+                      }
                     />
                   </div>
                 ))}
@@ -402,12 +413,6 @@ export const GameForm: React.FC<GameFormProps> = ({ onSave, initialGame }) => {
         </CardContent>
       </Card>
 
-      <DevelopmentCardEditor
-        deck={developmentCardDeck}
-        players={gamePlayers}
-        onDeckChange={setDevelopmentCardDeck}
-        onPlayersChange={setGamePlayers}
-      />
 
       <Card>
         <CardHeader>
@@ -571,7 +576,3 @@ export const generateDefaultDeck = (): DevelopmentCardDeck => ({
   monopoly: 2,
   totalRemaining: 25
 });
-
-// Import HexBoard component
-import { HexBoard } from './HexBoard';
-import { HexTile, ResourceType } from '../../models/types';


### PR DESCRIPTION
## 概要
DevelopmentCardEditor をプレイヤー単位の編集に対応させ、GameForm から各プレイヤーのカードを直接調整できるようにしました。

## 変更理由
ゲーム開始前に個々のプレイヤーの開発カードを管理しやすくするため。

## 主な変更点
- DevelopmentCardEditor を単一プレイヤー向けにリファクタリング
- GameForm でプレイヤーごとに DevelopmentCardEditor を配置
- 不要なインポートを整理

## 影響範囲
ゲーム作成・編集画面でのカード管理機能

------
https://chatgpt.com/codex/tasks/task_e_684ef6a3dcf0832a93e3d9bff8d72d34