### PR TITLE
プレイヤー選択の初期化処理を追加

### DIFF
--- a/src/components/game/BoardEditor.tsx
+++ b/src/components/game/BoardEditor.tsx
@@ -101,6 +101,14 @@ export const BoardEditor: React.FC<BoardEditorProps> = ({
   const [selectedPlayer, setSelectedPlayer] = useState<string>(gamePlayers[0]?.id || '');
   const [selectedBuildingType, setSelectedBuildingType] = useState<'settlement' | 'city'>('settlement');
 
+  // プレイヤー一覧が変化した場合に初期選択状態を補正する
+  React.useEffect(() => {
+    // 選択中のプレイヤーが存在しなければ先頭のプレイヤーを自動選択
+    if (!gamePlayers.some((p) => p.id === selectedPlayer)) {
+      setSelectedPlayer(gamePlayers[0]?.id || '');
+    }
+  }, [gamePlayers, selectedPlayer]);
+
   const availableVertices = React.useMemo(() => {
     if (selectedTool !== 'building' || !selectedPlayer) return [] as Vertex[];
     const verts: Vertex[] = [];


### PR DESCRIPTION
## 概要
ボードエディターでプレイヤーを変更できなくなる問題を修正しました。

## 変更理由
プレイヤー一覧が更新された際に選択状態が残ってしまい、存在しないプレイヤーIDを保持していたため。

## 主な変更点
- `BoardEditor.tsx` にプレイヤー一覧変化時の補正処理を追加

## 影響範囲
新規ゲームレコード作成時のボード編集機能

------
https://chatgpt.com/codex/tasks/task_e_6853902b8144832ab087755fd1efa3e5