### PR TITLE
プレイヤー未選択時の建設操作に警告を追加

### DIFF
--- a/src/components/game/BoardEditor.tsx
+++ b/src/components/game/BoardEditor.tsx
@@ -206,9 +206,6 @@ export const BoardEditor: React.FC<BoardEditorProps> = ({
         const existingBuilding = buildings.find((b) =>
           verticesEqual(b.position, vertex)
         );
-        const existingBuilding = buildings.find((b) =>
-          verticesEqual(b.position, vertex)
-        );
 
         if (existingBuilding) {
           // Remove existing building

--- a/src/components/game/BoardEditor.tsx
+++ b/src/components/game/BoardEditor.tsx
@@ -197,7 +197,15 @@ export const BoardEditor: React.FC<BoardEditorProps> = ({
 
   const handleVertexClick = useCallback(
     (vertex: Vertex) => {
-      if (selectedTool === 'building' && selectedPlayer) {
+      if (selectedTool === 'building') {
+        if (!selectedPlayer) {
+          alert('プレイヤーを選択してください');
+          return;
+        }
+        
+        const existingBuilding = buildings.find((b) =>
+          verticesEqual(b.position, vertex)
+        );
         const existingBuilding = buildings.find((b) =>
           verticesEqual(b.position, vertex)
         );
@@ -237,7 +245,12 @@ export const BoardEditor: React.FC<BoardEditorProps> = ({
 
   const handleEdgeClick = useCallback(
     (edge: Edge) => {
-      if (selectedTool === 'road' && selectedPlayer) {
+      if (selectedTool === 'road') {
+        if (!selectedPlayer) {
+          alert('プレイヤーを選択してください');
+          return;
+        }
+        
         const buildingCount = buildings.filter((b) => b.playerId === selectedPlayer).length;
         if (buildingCount === 0) {
           alert('先に家を置いてください');


### PR DESCRIPTION
## 概要
プレイヤーが選択されていない状態で頂点や辺をクリックした際、建物や道路を配置しようとすると警告を表示するようにしました。

## 変更理由
プレイヤー未選択のまま操作すると誤操作が発生するため、明示的にアラートを出してユーザーへ注意を促します。

## 主な変更点
- `BoardEditor.tsx` の `handleVertexClick` と `handleEdgeClick` にプレイヤー未選択時のチェックを追加

## 影響範囲
ボードエディタで建設・道路ツールを使用する際の挙動に影響します。

------
https://chatgpt.com/codex/tasks/task_e_6853957fac70832a8cf30091487309a9