### PR TITLE
編集画面でのボード編集機能を非表示化

### DIFF
--- a/src/components/game/GameForm.tsx
+++ b/src/components/game/GameForm.tsx
@@ -17,9 +17,15 @@ const playerColors: PlayerColor[] = ['red', 'blue', 'white', 'orange', 'green', 
 interface GameFormProps {
   onSave: () => void;
   initialGame?: GameSession;
+  /** 編集画面ではボード編集を無効化するためのフラグ */
+  editableBoard?: boolean;
 }
 
-export const GameForm: React.FC<GameFormProps> = ({ onSave, initialGame }) => {
+export const GameForm: React.FC<GameFormProps> = ({
+  onSave,
+  initialGame,
+  editableBoard = true
+}) => {
   const { players, addGame, updateGame, savedBoards, saveBoard } = useGameStore();
   
   const [date, setDate] = useState(initialGame?.date || format(new Date(), 'yyyy-MM-dd'));
@@ -50,6 +56,7 @@ export const GameForm: React.FC<GameFormProps> = ({ onSave, initialGame }) => {
     initialGame?.boardSetup || generateDefaultBoard(gameType)
   );
 
+  // 編集不可でも状態は保持するが、UIでは利用しない
   const [showBoardEditor, setShowBoardEditor] = useState(false);
   const [showBoardTemplates, setShowBoardTemplates] = useState(false);
   const [boardName, setBoardName] = useState('');
@@ -180,7 +187,7 @@ export const GameForm: React.FC<GameFormProps> = ({ onSave, initialGame }) => {
     onSave();
   };
 
-  if (showBoardEditor) {
+  if (editableBoard && showBoardEditor) {
     return (
       <div className="space-y-6">
         <div className="flex items-center justify-between">
@@ -218,7 +225,7 @@ export const GameForm: React.FC<GameFormProps> = ({ onSave, initialGame }) => {
     );
   }
 
-  if (showBoardTemplates) {
+  if (editableBoard && showBoardTemplates) {
     return (
       <div className="space-y-6">
         <div className="flex items-center justify-between">
@@ -383,26 +390,28 @@ export const GameForm: React.FC<GameFormProps> = ({ onSave, initialGame }) => {
         <Card>
           <CardHeader className="flex flex-row items-center justify-between">
             <CardTitle>Board Setup</CardTitle>
-            <div className="flex space-x-2">
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                onClick={() => setShowBoardTemplates(true)}
-                icon={<Grid size={16} />}
-              >
-                Templates
-              </Button>
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                onClick={() => setShowBoardEditor(true)}
-                icon={<Settings size={16} />}
-              >
-                Edit Board
-              </Button>
-            </div>
+            {editableBoard && (
+              <div className="flex space-x-2">
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setShowBoardTemplates(true)}
+                  icon={<Grid size={16} />}
+                >
+                  Templates
+                </Button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setShowBoardEditor(true)}
+                  icon={<Settings size={16} />}
+                >
+                  Edit Board
+                </Button>
+              </div>
+            )}
           </CardHeader>
         <CardContent>
           <div className="flex justify-center">

--- a/src/pages/EditGame.tsx
+++ b/src/pages/EditGame.tsx
@@ -49,9 +49,10 @@ export const EditGame: React.FC = () => {
       </LayoutHeader>
       
       <LayoutContent>
-        <GameForm 
-          initialGame={game} 
-          onSave={() => navigate(`/games/${id}`)} 
+        <GameForm
+          initialGame={game}
+          onSave={() => navigate(`/games/${id}`)}
+          editableBoard={false} // 既存ゲームではボード編集は不要
         />
       </LayoutContent>
     </Layout>


### PR DESCRIPTION
## 概要
ゲーム詳細画面から遷移する編集画面ではボード編集を行わないようにしました。

## 変更理由
既存ゲームの記録編集時にボードレイアウトを変更する必要がないため、編集UIを非表示にして操作を簡略化します。

## 主な変更点
- `GameForm` に `editableBoard` プロパティを追加し、ボード編集可否を制御
- `EditGame` から `GameForm` を呼び出す際に `editableBoard={false}` を指定
- ボード編集関連の表示・遷移を `editableBoard` が `true` の場合のみ有効化

## 影響範囲
既存の新規ゲーム作成画面には影響ありません。編集画面のみボード編集ボタンとエディター画面が表示されなくなります。

------
https://chatgpt.com/codex/tasks/task_e_68539dd74780832aafac3b965388ebce