### PR TITLE
プレイヤー管理の発展カード編集が反映されない問題を修正

### DIFF
--- a/src/components/game/DevelopmentCardTableEditor.tsx
+++ b/src/components/game/DevelopmentCardTableEditor.tsx
@@ -57,6 +57,18 @@ export const DevelopmentCardTableEditor: React.FC<DevelopmentCardTableEditorProp
   };
 
   // カードを追加
+  const applyChanges = (playerId: string, cards: DevelopmentCard[]) => {
+    // ゲーム開始前でも反映できるようローカル状態も更新する
+    updatePlayerDevelopmentCards(playerId, cards);
+    if (onChange) {
+      onChange(
+        players.map(p =>
+          p.id === playerId ? { ...p, developmentCards: cards } : p
+        )
+      );
+    }
+  };
+
   const addCard = (playerId: string, type: DevelopmentCardType) => {
     const player = players.find(p => p.id === playerId);
     if (!player) return;
@@ -70,7 +82,7 @@ export const DevelopmentCardTableEditor: React.FC<DevelopmentCardTableEditorProp
     };
 
     const updatedCards = [...(player.developmentCards ?? []), newCard];
-    updatePlayerDevelopmentCards(playerId, updatedCards);
+    applyChanges(playerId, updatedCards);
   };
 
   // カードを削除
@@ -82,7 +94,7 @@ export const DevelopmentCardTableEditor: React.FC<DevelopmentCardTableEditorProp
     const lastIndex = cards.map(c => c.type).lastIndexOf(type);
     if (lastIndex !== -1) {
       cards.splice(lastIndex, 1);
-      updatePlayerDevelopmentCards(playerId, cards);
+      applyChanges(playerId, cards);
     }
   };
 
@@ -99,7 +111,7 @@ export const DevelopmentCardTableEditor: React.FC<DevelopmentCardTableEditorProp
         const updatedCards = (player.developmentCards ?? []).map(card =>
           card.id === unusedKnight.id ? { ...card, isPlayed: true } : card
         );
-        updatePlayerDevelopmentCards(playerId, updatedCards);
+        applyChanges(playerId, updatedCards);
       }
     } else {
       const usedKnight = knightCards.find(card => card.isPlayed);
@@ -107,7 +119,7 @@ export const DevelopmentCardTableEditor: React.FC<DevelopmentCardTableEditorProp
         const updatedCards = (player.developmentCards ?? []).map(card =>
           card.id === usedKnight.id ? { ...card, isPlayed: false } : card
         );
-        updatePlayerDevelopmentCards(playerId, updatedCards);
+        applyChanges(playerId, updatedCards);
       }
     }
   };


### PR DESCRIPTION
## 概要
プレイヤー管理テーブルで発展カードの増減が反映されない不具合を修正しました。ゲーム開始前にローカル状態のみを変更していたため、ボタンを押しても表示が更新されませんでした。

## 変更内容
- `DevelopmentCardTableEditor` に `applyChanges` 関数を追加し、`onChange` が指定されている場合はローカル状態を更新するように修正
- カード追加・削除・騎士カード使用状態の更新処理で `applyChanges` を利用

## 影響範囲
プレイヤー管理画面でチャンスカード（発展カード）の枚数を変更すると即座に表示へ反映されます。既存のゲーム進行中の処理には影響しません。


------
https://chatgpt.com/codex/tasks/task_e_6853e9660c44832abfc89ca1164d5708