### PR TITLE
発展カード枚数制限の追加

### DIFF
--- a/src/models/types.ts
+++ b/src/models/types.ts
@@ -11,12 +11,25 @@ export type HarborType =
   | 'none';
 export type PlayerColor = 'red' | 'blue' | 'white' | 'orange' | 'green' | 'brown';
 
-export type DevelopmentCardType = 
-  | 'knight' 
-  | 'victory_point' 
-  | 'road_building' 
-  | 'year_of_plenty' 
+export type DevelopmentCardType =
+  | 'knight'
+  | 'victory_point'
+  | 'road_building'
+  | 'year_of_plenty'
   | 'monopoly';
+
+// ゲーム全体での発展カード枚数上限
+export const DEVELOPMENT_CARD_LIMITS: Record<DevelopmentCardType, number> = {
+  knight: 14,
+  victory_point: 5,
+  road_building: 2,
+  year_of_plenty: 2,
+  monopoly: 2
+};
+
+// 上記枚数の合計値（基本セットでは25枚）
+export const TOTAL_DEVELOPMENT_CARDS =
+  Object.values(DEVELOPMENT_CARD_LIMITS).reduce((a, b) => a + b, 0);
 
 export type VictoryPointCardType = 
   | 'university'


### PR DESCRIPTION
## 概要
発展カード(チャンスカード)の総枚数をルールどおりに制限する処理を追加しました。

## 変更点
- `models/types.ts` にカード枚数上限定数 `DEVELOPMENT_CARD_LIMITS` と `TOTAL_DEVELOPMENT_CARDS` を追加
- `DevelopmentCardTableEditor` で上限を考慮した追加処理とUIの更新
- カード追加ボタンが上限に達すると無効化されるよう調整

## 影響範囲
ゲーム作成画面のプレイヤー管理テーブルで発展カードを編集する際、総枚数が設定上限を超えなくなります。

------
https://chatgpt.com/codex/tasks/task_e_6853eb80268c832ab5d29efb276bf0e3