### PR TITLE
発展カード名の表記変更

### DIFF
--- a/src/components/game/DevelopmentCardEditor.tsx
+++ b/src/components/game/DevelopmentCardEditor.tsx
@@ -31,8 +31,8 @@ export const DevelopmentCardEditor: React.FC<DevelopmentCardEditorProps> = ({
   const cardTypeOptions: { value: DevelopmentCardType; label: string; description: string }[] = [
     { value: 'knight', label: '騎士', description: '盗賊を移動し、他プレイヤーからカードを奪う' },
     { value: 'victory_point', label: '勝利点', description: '1勝利点を獲得' },
-    { value: 'road_building', label: '道路建設', description: '道路を2本まで無料で建設' },
-    { value: 'year_of_plenty', label: '豊作', description: '好きな資源を2つ獲得' },
+    { value: 'road_building', label: '街道建設', description: '道路を2本まで無料で建設' },
+    { value: 'year_of_plenty', label: '収穫', description: '好きな資源を2つ獲得' },
     { value: 'monopoly', label: '独占', description: '指定した資源を全プレイヤーから獲得' }
   ];
 

--- a/src/components/game/DevelopmentCardTableEditor.tsx
+++ b/src/components/game/DevelopmentCardTableEditor.tsx
@@ -35,8 +35,8 @@ export const DevelopmentCardTableEditor: React.FC<DevelopmentCardTableEditorProp
   }[] = [
     { type: 'knight', label: '騎士', icon: <Sword size={14} />, color: 'text-red-600' },
     { type: 'victory_point', label: '勝利点', icon: <Trophy size={14} />, color: 'text-amber-600' },
-    { type: 'road_building', label: '道路建設', icon: <Route size={14} />, color: 'text-blue-600' },
-    { type: 'year_of_plenty', label: '豊作', icon: <Coins size={14} />, color: 'text-green-600' },
+    { type: 'road_building', label: '街道建設', icon: <Route size={14} />, color: 'text-blue-600' },
+    { type: 'year_of_plenty', label: '収穫', icon: <Coins size={14} />, color: 'text-green-600' },
     { type: 'monopoly', label: '独占', icon: <Building size={14} />, color: 'text-purple-600' }
   ];
 

--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -666,8 +666,8 @@ export const useGameStore = create<GameState>()(
 function getCardName(type: DevelopmentCardType): string {
   switch (type) {
     case 'knight': return '騎士';
-    case 'road_building': return '道路建設';
-    case 'year_of_plenty': return '豊作';
+    case 'road_building': return '街道建設';
+    case 'year_of_plenty': return '収穫';
     case 'monopoly': return '独占';
     case 'victory_point': return '勝利点';
     default: return 'Unknown';


### PR DESCRIPTION
## 概要
豊作カードと道路建設カードの日本語表記を更新しました。

## 変更理由
ゲーム内表示をより一般的な名称へ統一するため。

## 主な変更点
- DevelopmentCardEditor のラベル更新
- DevelopmentCardTableEditor のラベル更新
- gameStore のカード名取得関数を更新


------
https://chatgpt.com/codex/tasks/task_e_6854471f1820832ab82f4e835c87a564