### PR TITLE
使用済み騎士の枚数表示を改善

### DIFF
--- a/src/components/game/DevelopmentCardEditor.tsx
+++ b/src/components/game/DevelopmentCardEditor.tsx
@@ -159,7 +159,7 @@ export const DevelopmentCardEditor: React.FC<DevelopmentCardEditorProps> = ({
                       icon={<Minus size={12} />}
                     />
                     <span className="w-8 text-center text-sm font-medium text-red-600">
-                      {playedKnights}
+                      {playedKnights}/{cardCounts.knight}
                     </span>
                     <Button
                       type="button"

--- a/src/components/game/DevelopmentCardTableEditor.tsx
+++ b/src/components/game/DevelopmentCardTableEditor.tsx
@@ -304,8 +304,8 @@ export const DevelopmentCardTableEditor: React.FC<DevelopmentCardTableEditorProp
                           icon={<Minus size={12} />}
                           className="h-6 w-6 p-0"
                         />
-                        <span className="w-6 text-center font-medium text-sm text-red-600">
-                          {playedKnights}
+                        <span className="w-10 text-center font-medium text-sm text-red-600">
+                          {playedKnights}/{totalKnights}
                         </span>
                         <Button
                           type="button"
@@ -383,7 +383,8 @@ export const DevelopmentCardTableEditor: React.FC<DevelopmentCardTableEditorProp
             <div className="text-center">
               <div className="text-gray-500">使用済み騎士</div>
               <div className="font-bold text-lg text-red-600">
-                {players.reduce((sum, p) => sum + getPlayedKnights(p), 0)}
+                {players.reduce((sum, p) => sum + getPlayedKnights(p), 0)} /
+                {players.reduce((sum, p) => sum + getCardCount(p, 'knight'), 0)}
               </div>
             </div>
             <div className="text-center">

--- a/src/components/game/PlayerPanel.tsx
+++ b/src/components/game/PlayerPanel.tsx
@@ -152,7 +152,7 @@ export const PlayerPanel: React.FC<PlayerPanelProps> = ({
                 Knights:
               </span>
               <span className="font-medium text-red-600">
-                {cardCounts.knight} ({playedKnights} used)
+                {playedKnights}/{cardCounts.knight}
               </span>
             </div>
           )}


### PR DESCRIPTION
## 概要
騎士カードの使用済み枚数を総数と合わせて表示するように変更しました。

## 変更理由
使用済み枚数だけでは残り枚数が分かりにくいため、総数も併記して把握しやすくするためです。

## 主な変更点
- PlayerPanel で騎士枚数を `使用済み/総数` 表記に変更
- DevelopmentCardEditor と DevelopmentCardTableEditor でも同様の形式に変更

------
https://chatgpt.com/codex/tasks/task_e_685adc2f1a90832a9d6df6434a9cc251