### PR TITLE
騎士カード枚数表示の色変更

### DIFF
--- a/src/components/game/DevelopmentCardTableEditor.tsx
+++ b/src/components/game/DevelopmentCardTableEditor.tsx
@@ -375,14 +375,14 @@ export const DevelopmentCardTableEditor: React.FC<DevelopmentCardTableEditorProp
             </div>
             <div className="text-center">
               <div className="text-gray-500">総騎士カード</div>
-              <div className="font-bold text-lg text-red-600">
+              <div className="font-bold text-lg text-black">
                 {players.reduce((sum, p) => sum + getCardCount(p, 'knight'), 0)}
                 / {DEVELOPMENT_CARD_LIMITS['knight']}
               </div>
             </div>
             <div className="text-center">
               <div className="text-gray-500">使用済み騎士</div>
-              <div className="font-bold text-lg text-red-600">
+              <div className="font-bold text-lg text-black">
                 {players.reduce((sum, p) => sum + getPlayedKnights(p), 0)} /
                 {players.reduce((sum, p) => sum + getCardCount(p, 'knight'), 0)}
               </div>


### PR DESCRIPTION
## 概要
開発カード集計テーブルで表示している騎士カード関連の数値が赤色となっていたため、黒色に変更しました。

## 変更理由
他の数値表示と統一し、視認性を高めるためです。

## 主な変更点
- `DevelopmentCardTableEditor.tsx` の総騎士カードおよび使用済み騎士の表示色を `text-red-600` から `text-black` に変更

## 影響範囲
UI 表示のみ

------
https://chatgpt.com/codex/tasks/task_e_685addc33280832a9b70bb4e7ebaf63c