### PR TITLE
ゲーム詳細をオブジェクト化

### DIFF
--- a/src/components/game/GameCard.tsx
+++ b/src/components/game/GameCard.tsx
@@ -48,10 +48,10 @@ export const GameCard: React.FC<GameCardProps> = ({ game, onClick }) => {
             </div>
           )}
           
-          {game.tags.length > 0 && (
+          {game.gameDetails.tags.length > 0 && (
             <div className="flex flex-wrap gap-1 mt-2">
-              {game.tags.map(tag => (
-                <span 
+              {game.gameDetails.tags.map(tag => (
+                <span
                   key={tag}
                   className="px-2 py-0.5 rounded-full text-xs bg-gray-100 text-gray-600"
                 >

--- a/src/components/game/GameForm.tsx
+++ b/src/components/game/GameForm.tsx
@@ -28,8 +28,8 @@ export const GameForm: React.FC<GameFormProps> = ({ onSave, initialGame }) => {
   
   const [date, setDate] = useState(initialGame?.date || format(new Date(), 'yyyy-MM-dd'));
   const [duration, setDuration] = useState(initialGame?.duration || 60);
-  const [notes, setNotes] = useState(initialGame?.notes || '');
-  const [tags, setTags] = useState<string[]>(initialGame?.tags || []);
+  const [notes, setNotes] = useState(initialGame?.gameDetails?.notes || '');
+  const [tags, setTags] = useState<string[]>(initialGame?.gameDetails?.tags || []);
   const [newTag, setNewTag] = useState('');
   const [gameType, setGameType] = useState<'standard' | 'seafarers' | 'cities' | 'traders' | 'america'>('standard');
   
@@ -114,8 +114,10 @@ export const GameForm: React.FC<GameFormProps> = ({ onSave, initialGame }) => {
       winner: gamePlayers.find(p => p.rank === 1)?.playerId || '',
       boardSetup,
       developmentCardDeck,
-      notes,
-      tags
+      gameDetails: {
+        notes,
+        tags
+      }
     };
     
     if (initialGame) {

--- a/src/models/types.ts
+++ b/src/models/types.ts
@@ -169,6 +169,11 @@ export interface DevelopmentCardDeck {
   totalRemaining: number;
 }
 
+export interface GameDetails {
+  notes: string;
+  tags: string[];
+}
+
 export interface GameSession {
   id: string;
   date: string;
@@ -176,8 +181,7 @@ export interface GameSession {
   players: GamePlayer[];
   winner: string; // player ID
   boardSetup: BoardSetup;
-  notes: string;
-  tags: string[];
+  gameDetails: GameDetails;
   currentTurn: number;
   currentPlayer: string;
   developmentCardDeck: DevelopmentCardDeck;

--- a/src/pages/GameDetails.tsx
+++ b/src/pages/GameDetails.tsx
@@ -245,24 +245,24 @@ export const GameDetails: React.FC = () => {
                   </div>
                 </div>
                 
-                {game.notes && (
+                {game.gameDetails.notes && (
                   <div className="mb-6">
                     <h3 className="text-sm font-medium text-gray-500 mb-2">
                       Game Notes
                     </h3>
-                    <p className="text-gray-900 bg-gray-50 p-3 rounded">{game.notes}</p>
+                    <p className="text-gray-900 bg-gray-50 p-3 rounded">{game.gameDetails.notes}</p>
                   </div>
                 )}
-                
-                {game.tags.length > 0 && (
+
+                {game.gameDetails.tags.length > 0 && (
                   <div>
                     <h3 className="text-sm font-medium text-gray-500 mb-2">
                       Tags
                     </h3>
                     <div className="flex flex-wrap gap-2">
-                      {game.tags.map(tag => (
-                        <span 
-                          key={tag} 
+                      {game.gameDetails.tags.map(tag => (
+                        <span
+                          key={tag}
                           className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-emerald-100 text-emerald-800"
                         >
                           {tag}

--- a/src/pages/GamesList.tsx
+++ b/src/pages/GamesList.tsx
@@ -24,12 +24,12 @@ export const GamesList: React.FC = () => {
     );
     
     // Search in tags
-    const tagMatch = game.tags.some(tag => 
+    const tagMatch = game.gameDetails.tags.some(tag =>
       tag.toLowerCase().includes(searchLower)
     );
-    
+
     // Search in notes
-    const notesMatch = game.notes.toLowerCase().includes(searchLower);
+    const notesMatch = game.gameDetails.notes.toLowerCase().includes(searchLower);
     
     // Search in date
     const dateMatch = game.date.includes(searchTerm);


### PR DESCRIPTION
## 概要
GameSessionのメモとタグを`gameDetails`としてまとめ、各種処理を更新しました。

## 変更理由
メモやタグを将来的に拡張しやすくするために、ゲーム固有情報を一つのオブジェクトで管理するようにしました。また、旧データも自動で変換できるよう対応しています。

## 主な変更点
- `GameSession`型に`gameDetails`を追加し、`notes`/`tags`を統合
- ゲーム管理ストアでの新規開始・追加・更新処理を修正
- 旧データ読み込み時に自動で`gameDetails`へ変換するロジックを実装
- フォームや表示コンポーネントを新構造に対応


------
https://chatgpt.com/codex/tasks/task_e_685c31132098832a8e34273f81ed8335